### PR TITLE
fix: adjust the style to support the latest primevue version v3.36+

### DIFF
--- a/style-sheets/primevue-components-overrides.scss
+++ b/style-sheets/primevue-components-overrides.scss
@@ -125,8 +125,8 @@ label {
         lightButton.$light-button-token-overrides,
         'button-primary'
     );
-    outline: 0.125rem solid #ffffff !important;
-    outline-offset: -0.25rem;
+    outline: 0.075rem solid #ffffff !important;
+    outline-offset: -0.2rem;
     box-shadow: unset !important;
 }
 
@@ -170,8 +170,8 @@ label {
         'button-tertiary-active'
     ) !important;
     color: map.get(lightTheme.$light-theme, 'text-on-color');
-    outline: 0.125rem solid #ffffff;
-    outline-offset: -0.25rem;
+    outline: 0.075rem solid #ffffff;
+    outline-offset: -0.2rem;
     box-shadow: unset;
 }
 .#{variables.$primevue-prefix}-button.#{variables.$primevue-prefix}-button-outlined:disabled {

--- a/style-sheets/primevue-components-overrides.scss
+++ b/style-sheets/primevue-components-overrides.scss
@@ -140,6 +140,7 @@ label {
         lightButton.$light-button-token-overrides,
         'button-tertiary'
     );
+    background-color: transparent;
 }
 .#{variables.$primevue-prefix}-button.#{variables.$primevue-prefix}-button-outlined:enabled:hover {
     background: map.get(
@@ -609,12 +610,15 @@ label {
 .#{variables.$primevue-prefix}-dialog-footer {
     border-top: none;
     padding-bottom: 4rem !important;
+    border-bottom-right-radius: 0.5rem;
+    border-bottom-left-radius: 0.5rem;
 }
 
 .#{variables.$primevue-prefix}-dialog
-    .#{variables.$primevue-prefix}-dialog-footer {
-    border-bottom-right-radius: 0.5rem;
-    border-bottom-left-radius: 0.5rem;
+    .#{variables.$primevue-prefix}-dialog-footer
+    button {
+    margin: 0 0.5rem 0 0;
+    width: auto;
 }
 
 /* ------------------------------------ dialog confirm header -------------------------- */
@@ -632,12 +636,6 @@ label {
     .#{variables.$primevue-prefix}-dialog-title {
         @extend %heading-03;
     }
-}
-
-.#{variables.$primevue-prefix}-dialog
-    .#{variables.$primevue-prefix}-dialog-footer {
-    border-top: none;
-    padding-bottom: 4rem !important;
 }
 
 .#{variables.$primevue-prefix}-dialog
@@ -670,6 +668,11 @@ label {
 .#{variables.$primevue-prefix}-confirm-dialog-reject:enabled:focus {
     border: 0.0625rem solid
         map.get(lightButton.$light-button-token-overrides, 'button-tertiary') !important;
+}
+
+.#{variables.$primevue-prefix}-dialog
+    .#{variables.$primevue-prefix}-confirm-dialog-reject {
+    background: transparent;
 }
 
 .#{variables.$primevue-prefix}-button
@@ -777,10 +780,20 @@ label {
 
 /* ------------------------------------ primevue message --------------------------------- */
 
+.#{variables.$primevue-prefix}-icon {
+    height: 0.75rem;
+    width: 0.75rem;
+}
+
 .#{variables.$primevue-prefix}-message {
     position: absolute;
     left: 0;
     right: 0;
+}
+
+.#{variables.$primevue-prefix}-message
+    .#{variables.$primevue-prefix}-message-wrapper {
+    padding: 0.5rem 0.5rem 0.5rem 0;
 }
 
 .#{variables.$primevue-prefix}-message
@@ -806,9 +819,10 @@ label {
     vertical-align: middle;
 }
 
-.#{variables.$primevue-prefix}-message
-    .#{variables.$primevue-prefix}-message-wrapper {
-    padding: 0.5rem 0.5rem 0.5rem 0;
+.#{variables.$primevue-prefix}-message-close.#{variables.$primevue-prefix}-link {
+    margin-left: auto;
+    overflow: hidden;
+    position: relative;
 }
 
 .#{variables.$primevue-prefix}-message-wrapper
@@ -821,11 +835,6 @@ label {
 .#{variables.$primevue-prefix}-message
     .#{variables.$primevue-prefix}-message-close:hover {
     background: none;
-}
-
-.#{variables.$primevue-prefix}-icon {
-    height: 0.75rem;
-    width: 0.75rem;
 }
 
 .#{variables.$primevue-prefix}-message-wrapper

--- a/style-sheets/primevue-components-overrides.scss
+++ b/style-sheets/primevue-components-overrides.scss
@@ -1155,12 +1155,13 @@ label {
 .#{variables.$primevue-prefix}-tabview
     .#{variables.$primevue-prefix}-tabview-panels {
     padding: 0;
-    background-color: transparent;
 }
 
 .#{variables.$primevue-prefix}-tabview
     .#{variables.$primevue-prefix}-tabview-nav {
     border: none;
+    padding: 0;
+    margin: 0;
 }
 
 .#{variables.$primevue-prefix}-tabview
@@ -1175,7 +1176,9 @@ label {
     border-radius: 0;
     border: none;
     border-top: 0.125rem solid transparent;
-    border-bottom: 0.125rem solid transparent;
+    border-bottom: 0.0625rem solid transparent;
+    text-decoration: none;
+    color: map.get(lightTheme.$light-theme, 'text-primary')
 }
 
 .#{variables.$primevue-prefix}-tabview
@@ -1209,6 +1212,7 @@ label {
     font-weight: 700;
     border-top: solid 0.125rem
         map.get(lightTheme.$light-theme, 'border-interactive') !important;
+    background-color: #ffffff;
 }
 
 .#{variables.$primevue-prefix}-tabview
@@ -1240,7 +1244,7 @@ label {
     box-shadow: none !important;
     outline: 0.125rem solid
         map.get(lightTheme.$light-theme, 'border-interactive') !important;
-    outline-offset: -0.12rem !important;
+    outline-offset: -0.125rem !important;
 }
 
 @media (min-width: 500px) {

--- a/style-sheets/primevue-components-overrides.scss
+++ b/style-sheets/primevue-components-overrides.scss
@@ -207,6 +207,7 @@ label {
     .#{variables.$primevue-prefix}-inputtext {
     width: 100%;
     height: 100%;
+    padding-left: 2.5rem;
 }
 
 /* -------------------------------------- primevue dropdown ------------------------------------ */
@@ -223,6 +224,8 @@ label {
 .#{variables.$primevue-prefix}-dropdown
     .#{variables.$primevue-prefix}-dropdown-label {
     @extend %body-compact-01;
+    border: 0 none;
+    background: transparent;
 }
 
 .#{variables.$primevue-prefix}-dropdown .#{variables.$primevue-prefix}-icon {
@@ -258,6 +261,7 @@ label {
 .#{variables.$primevue-prefix}-dropdown-panel
     .#{variables.$primevue-prefix}-dropdown-items {
     padding: 0;
+    margin: 0;
 }
 .#{variables.$primevue-prefix}-dropdown-panel
     .#{variables.$primevue-prefix}-dropdown-items

--- a/style-sheets/primevue-components-overrides.scss
+++ b/style-sheets/primevue-components-overrides.scss
@@ -608,7 +608,7 @@ label {
 }
 
 .#{variables.$primevue-prefix}-dialog-footer {
-    border-top: none;
+    border-top: none !important;
     padding-bottom: 4rem !important;
     border-bottom-right-radius: 0.5rem;
     border-bottom-left-radius: 0.5rem;


### PR DESCRIPTION
Looks like the latest primevue version will ignore the default style if we make any custom style changes for a specific class. So have to copy some default style over to include it in some special case. 