### PR TITLE
fix(primevue): Breadcrumb component

### DIFF
--- a/style-sheets/primevue-components-overrides.scss
+++ b/style-sheets/primevue-components-overrides.scss
@@ -997,12 +997,58 @@ label {
 
 .#{variables.$primevue-prefix}-breadcrumb
     .#{variables.$primevue-prefix}-breadcrumb-list
+    .#{variables.$primevue-prefix}-menuitem
+    a {
+    padding: 0.2rem;
+    border-radius: 0;
+    text-decoration: none;
+}
+
+.#{variables.$primevue-prefix}-breadcrumb
+    .#{variables.$primevue-prefix}-breadcrumb-list
+    .#{variables.$primevue-prefix}-menuitem
+    a {
+    box-shadow: inset 0 0px 0px 0.063rem
+        map.get(lightTheme.$light-theme, 'focus') !important;
+}
+
+.#{variables.$primevue-prefix}-breadcrumb
+    .#{variables.$primevue-prefix}-breadcrumb-list
+    .#{variables.$primevue-prefix}-menuitem:last-child
+    a {
+    box-shadow: none !important;
+    pointer-events: none;
+}
+
+.#{variables.$primevue-prefix}-breadcrumb
+    .#{variables.$primevue-prefix}-breadcrumb-list
+    .#{variables.$primevue-prefix}-menuitem
+    a
+    span:hover {
+    color: map.get(lightTheme.$light-theme, 'link-primary-hover') !important;
+}
+
+.#{variables.$primevue-prefix}-breadcrumb
+    .#{variables.$primevue-prefix}-breadcrumb-list
     .#{variables.$primevue-prefix}-menuitem:not(:last-child)::after {
     color: map.get(lightTheme.$light-theme, 'text-primary');
     content: '/';
     margin: 0 0.5rem;
 }
 
+.#{variables.$primevue-prefix}-breadcrumb
+    .#{variables.$primevue-prefix}-breadcrumb-list
+    li
+    span {
+    color: map.get(lightTheme.$light-theme, 'link-primary') !important;
+}
+
+.#{variables.$primevue-prefix}-breadcrumb
+    .#{variables.$primevue-prefix}-breadcrumb-list
+    li:last-child
+    span {
+    color: map.get(lightTheme.$light-theme, 'text-primary') !important;
+}
 
 .#{variables.$primevue-prefix}-breadcrumb
     .#{variables.$primevue-prefix}-breadcrumb-list

--- a/style-sheets/primevue-components-overrides.scss
+++ b/style-sheets/primevue-components-overrides.scss
@@ -997,58 +997,12 @@ label {
 
 .#{variables.$primevue-prefix}-breadcrumb
     .#{variables.$primevue-prefix}-breadcrumb-list
-    .#{variables.$primevue-prefix}-menuitem
-    .#{variables.$primevue-prefix}-menuitem-link {
-    padding: 0.2rem;
-    border-radius: 0;
-    text-decoration: none;
-}
-
-.#{variables.$primevue-prefix}-breadcrumb
-    .#{variables.$primevue-prefix}-breadcrumb-list
-    .#{variables.$primevue-prefix}-menuitem
-    .#{variables.$primevue-prefix}-menuitem-link:focus {
-    box-shadow: inset 0 0px 0px 0.063rem
-        map.get(lightTheme.$light-theme, 'focus') !important;
-}
-
-.#{variables.$primevue-prefix}-breadcrumb
-    .#{variables.$primevue-prefix}-breadcrumb-list
-    .#{variables.$primevue-prefix}-menuitem:last-child
-    .#{variables.$primevue-prefix}-menuitem-link {
-    box-shadow: none !important;
-    pointer-events: none;
-}
-
-.#{variables.$primevue-prefix}-breadcrumb
-    .#{variables.$primevue-prefix}-breadcrumb-list
-    .#{variables.$primevue-prefix}-menuitem
-    .#{variables.$primevue-prefix}-menuitem-link
-    .#{variables.$primevue-prefix}-menuitem-text:hover {
-    color: map.get(lightTheme.$light-theme, 'link-primary-hover') !important;
-}
-
-.#{variables.$primevue-prefix}-breadcrumb
-    .#{variables.$primevue-prefix}-breadcrumb-list
     .#{variables.$primevue-prefix}-menuitem:not(:last-child)::after {
     color: map.get(lightTheme.$light-theme, 'text-primary');
     content: '/';
     margin: 0 0.5rem;
 }
 
-.#{variables.$primevue-prefix}-breadcrumb
-    .#{variables.$primevue-prefix}-breadcrumb-list
-    li
-    .#{variables.$primevue-prefix}-menuitem-text {
-    color: map.get(lightTheme.$light-theme, 'link-primary') !important;
-}
-
-.#{variables.$primevue-prefix}-breadcrumb
-    .#{variables.$primevue-prefix}-breadcrumb-list
-    li:last-child
-    .#{variables.$primevue-prefix}-menuitem-text {
-    color: map.get(lightTheme.$light-theme, 'text-primary') !important;
-}
 
 .#{variables.$primevue-prefix}-breadcrumb
     .#{variables.$primevue-prefix}-breadcrumb-list

--- a/style-sheets/primevue-components-overrides.scss
+++ b/style-sheets/primevue-components-overrides.scss
@@ -1007,7 +1007,7 @@ label {
 .#{variables.$primevue-prefix}-breadcrumb
     .#{variables.$primevue-prefix}-breadcrumb-list
     .#{variables.$primevue-prefix}-menuitem
-    a {
+    a:focus {
     box-shadow: inset 0 0px 0px 0.063rem
         map.get(lightTheme.$light-theme, 'focus') !important;
 }


### PR DESCRIPTION
- Removing styling that is now on local due to change to template syntax.

Styling for Breadcrumb was broken after primevue removed vue-router support from menu components.
https://github.com/primefaces/primevue/issues/4739
