### PR TITLE
fix(primevue): tab component styling on mobile

### DIFF
--- a/style-sheets/primevue-components-overrides.scss
+++ b/style-sheets/primevue-components-overrides.scss
@@ -1215,7 +1215,11 @@ label {
 
 @media (max-width: 390px) {
     .#{variables.$primevue-prefix}-tabview
-        .#{variables.$primevue-prefix}-tabview-nav {
-        display: none;
+        .#{variables.$primevue-prefix}-tabview-nav-link {
+        min-width: 6.9rem !important;
+    }
+    .#{variables.$primevue-prefix}-tabview
+        .#{variables.$primevue-prefix}-tabview-title {
+            padding-right: 0.625rem;
     }
 }


### PR DESCRIPTION
- tab component now display on mobile
ref: https://github.com/orgs/bcgov/projects/65/views/1?pane=issue&itemId=62423406